### PR TITLE
Fix symbolic link of README.md

### DIFF
--- a/protocheck/README.md
+++ b/protocheck/README.md
@@ -1,1 +1,1 @@
-/home/rick/protocheck/README.md
+../README.md


### PR DESCRIPTION
The symbolic link of README.md uses absolute path instead of relative path.